### PR TITLE
Fix namespace labels

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -19,7 +19,7 @@ local namespace = operatorlib.validateInstance(params.namespace);
           // enable cluster monitoring when instantiating to manage
           // namespace openshift-operators-redhat
           'openshift.io/cluster-monitoring':
-            namespace == 'openshift-operators-redhat',
+            '%s' % [ namespace == 'openshift-operators-redhat' ],
         },
       },
     },


### PR DESCRIPTION
The component accidentally provided label `openshift.io/cluster-monitoring` with a boolean value which caused
ArgoCD to discard the existing `metadata.labels` on the namespace object.

This commit ensures that the label `openshift.io/cluster-monitoring` has a string value which fixes the problem.

Fixes #2.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
