### PR TITLE
Don't include operator namespaces in user workload monitoring

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -18,6 +18,8 @@ local namespace = operatorlib.validateInstance(params.namespace);
           // namespace openshift-operators-redhat
           'openshift.io/cluster-monitoring':
             '%s' % [ namespace == 'openshift-operators-redhat' ],
+          // ignore namespace by user-workload monitoring
+          'openshift.io/user-monitoring': 'false',
         },
       },
     },

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "source": {
+                "git": {
+                    "remote": "https://github.com/bitnami-labs/kube-libsonnet"
+                }
+            },
+            "version": "v1.19.0"
+        }
+    ],
+    "legacyImports": true
+}

--- a/tests/golden/openshift-operators-redhat/openshift-operators-redhat/openshift4-operators/openshift-operators-redhat.yaml
+++ b/tests/golden/openshift-operators-redhat/openshift-operators-redhat/openshift4-operators/openshift-operators-redhat.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     name: openshift-operators-redhat
     openshift.io/cluster-monitoring: 'true'
+    openshift.io/user-monitoring: 'false'
   name: openshift-operators-redhat
 ---
 apiVersion: operators.coreos.com/v1

--- a/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
+++ b/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     name: openshift-operators
     openshift.io/cluster-monitoring: 'false'
+    openshift.io/user-monitoring: 'false'
   name: openshift-operators
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
This MR adds the `openshift.io/user-monitoring: 'false'` label to managed namespaces, which will make sure that the namespaces are ignored by user workload monitoring.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.