### PR TITLE
Allow use of custom namespace names for this component

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - openshift-operators-redhat
           - openshift-operators
+          - openshift-operators-custom
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +51,7 @@ jobs:
         instance:
           - openshift-operators-redhat
           - openshift-operators
+          - openshift-operators-custom
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= openshift-operators-redhat
-test_instances = tests/openshift-operators-redhat.yml tests/openshift-operators.yml
+test_instances = tests/openshift-operators-redhat.yml tests/openshift-operators.yml tests/openshift-operators-custom.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,6 +7,7 @@ parameters:
       openshift.io/node-selector: node-role.kubernetes.io/infra=
     defaultInstallPlanApproval: Automatic
     defaultSourceNamespace: openshift-marketplace
+    useCustomNamespace: false
 
     monitoring:
       enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -9,7 +9,7 @@ type:: string
 default:: `${_instance}`
 
 The namespace to create for the component instance.
-The component is implemented in such a way that only instances (and therefore namespaces) `openshift-operators` and `openshift-operators-redhat` can be created.
+The component is implemented in such a way that only instances (and therefore namespaces) `openshift-operators` and `openshift-operators-redhat` can be created, unless `useCustomNamespace` is set to `true`.
 Generally, it shouldn't be necessary to override this parameter.
 
 == `namespaceAnnotations`
@@ -62,6 +62,15 @@ This parameter configures the default value for the optional parameter `source` 
 The component defaults to `certified-operators` for instance `openshift-operators`.
 This source provides community-maintained operators which are certified by RedHat.
 Alternatively, you can use `community-operators` for other community-maintained operators.
+
+== `useCustomNamespace`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+Whether to allow non-standard namespace names for the OperatorGroup.
+If this parameter is set to `true`, the component will allow using namespace names other than `openshift-operators` and `openshift-operators-redhat`.
 
 == `monitoring`
 

--- a/lib/openshift4-operators.libsonnet
+++ b/lib/openshift4-operators.libsonnet
@@ -37,8 +37,10 @@ local validateInstance(instance, checkTargets=false, checkSource='') =
     'openshift-operators-redhat',
   ]);
 
+  local use_custom_namespace = instanceParams(instance).useCustomNamespace;
+
   assert
-    std.setMember(instance, supported_instances) :
+    use_custom_namespace || std.setMember(instance, supported_instances) :
     "\n  Invalid instance '%s' for component openshift4-operators." % [
       instance,
     ] +

--- a/tests/golden/openshift-operators-custom/openshift-operators-custom/openshift4-operators/monitoring.yaml
+++ b/tests/golden/openshift-operators-custom/openshift-operators-custom/openshift4-operators/monitoring.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/infra: 'true'
+    name: syn-monitoring-openshift4-operators
+  name: syn-monitoring-openshift4-operators
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-marketplace-operator
+  name: openshift-marketplace-operator
+  namespace: syn-monitoring-openshift4-operators
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: marketplace-operator-metrics.openshift-marketplace.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-marketplace
+  selector:
+    matchLabels:
+      name: marketplace-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-catalog-operator
+  name: openshift-catalog-operator
+  namespace: syn-monitoring-openshift4-operators
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: catalog-operator-metrics.openshift-operator-lifecycle-manager.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-operator-lifecycle-manager
+  selector:
+    matchLabels:
+      app: catalog-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-olm-operator
+  name: openshift-olm-operator
+  namespace: syn-monitoring-openshift4-operators
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: olm-operator-metrics.openshift-operator-lifecycle-manager.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-operator-lifecycle-manager
+  selector:
+    matchLabels:
+      app: olm-operator

--- a/tests/golden/openshift-operators-custom/openshift-operators-custom/openshift4-operators/openshift-operators-custom.yaml
+++ b/tests/golden/openshift-operators-custom/openshift-operators-custom/openshift4-operators/openshift-operators-custom.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
+  labels:
+    name: openshift-operators-custom
+    openshift.io/cluster-monitoring: 'false'
+    openshift.io/user-monitoring: 'false'
+  name: openshift-operators-custom
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-operators-custom
+  name: openshift-operators-custom
+  namespace: openshift-operators-custom

--- a/tests/openshift-operators-custom.yml
+++ b/tests/openshift-operators-custom.yml
@@ -1,0 +1,15 @@
+applications:
+  - prometheus
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: infra
+
+  openshift_operators_custom:
+    useCustomNamespace: true


### PR DESCRIPTION
This allows the component to be deployed into arbitrary namespaces. Since this is officially a "workaround", this feature has to be enabled explicitly via parameters; by default, the validation rejects non-standard namespaces as usual.

Additionally, fixed some potential naming conflicts in the output directory and argocd app.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
