### PR TITLE
Always use `openshift-operators` as default namespace in ArgoCD app

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,7 +3,10 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_operators;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('openshift4-operators', params.namespace);
+// Use `openshift-operators` as fallback namespace
+// By using a static value here, we don't get unexpected changes when users
+// create new instances of this component.
+local app = argocd.App('openshift4-operators', 'openshift-operators');
 
 {
   'openshift4-operators': app,


### PR DESCRIPTION
Always use namespace `openshift-operators` as fallback target namespace in the ArgoCD app to ensure the app is deterministic when multiple instances of the component are active.

Since we ensure that all manifests defined in the component have `metadata.namespace` set, the ArgoCD app's default namespace field should never get used. Using `openshift-operators` is a safe default, since that namespace is always present.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
