### PR TITLE
Don't take over ownership of OpenShift-managed namespace `openshift-operators`

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -2,32 +2,44 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local operatorlib = import 'lib/openshift4-operators.libsonnet';
+local po = import 'lib/patch-operator.libsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_operators;
 
 
 local namespace = operatorlib.validateInstance(params.namespace);
 
+local nsmeta = {
+  metadata+: {
+    annotations+: std.prune(params.namespaceAnnotations),
+    labels+: {
+      // enable cluster monitoring when instantiating to manage
+      // namespace openshift-operators-redhat
+      'openshift.io/cluster-monitoring':
+        '%s' % [ namespace == 'openshift-operators-redhat' ],
+      // ignore namespace by user-workload monitoring
+      'openshift.io/user-monitoring': 'false',
+    },
+  },
+};
+local ns = kube.Namespace(namespace) + nsmeta;
+
+local operatorgroup =
+  // Create cluster-scoped OperatorGroup
+  operatorlib.OperatorGroup(namespace) {
+    metadata+: {
+      namespace: namespace,
+    },
+  };
+
+local nspatch = po.Patch(ns, nsmeta);
+
 {
-  [namespace]: [
-    kube.Namespace(namespace) {
-      metadata+: {
-        annotations+: std.prune(params.namespaceAnnotations),
-        labels+: {
-          // enable cluster monitoring when instantiating to manage
-          // namespace openshift-operators-redhat
-          'openshift.io/cluster-monitoring':
-            '%s' % [ namespace == 'openshift-operators-redhat' ],
-          // ignore namespace by user-workload monitoring
-          'openshift.io/user-monitoring': 'false',
-        },
-      },
-    },
-    // Create cluster-scoped OperatorGroup
-    operatorlib.OperatorGroup(namespace) {
-      metadata+: {
-        namespace: namespace,
-      },
-    },
-  ],
+  [namespace]:
+    if namespace != 'openshift-operators' then [
+      ns,
+      operatorgroup,
+    ]
+    else nspatch,
 }

--- a/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
+++ b/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
@@ -1,19 +1,26 @@
-apiVersion: v1
-kind: Namespace
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
 metadata:
   annotations:
-    openshift.io/node-selector: node-role.kubernetes.io/infra=
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
-    name: openshift-operators
-    openshift.io/cluster-monitoring: 'false'
-    openshift.io/user-monitoring: 'false'
-  name: openshift-operators
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  annotations: {}
-  labels:
-    name: openshift-operators
-  name: openshift-operators
-  namespace: openshift-operators
+    name: namespace-openshift-operators-29c692296e708c9
+  name: namespace-openshift-operators-29c692296e708c9
+  namespace: syn-patch-operator
+spec:
+  patches:
+    namespace-openshift-operators-29c692296e708c9-patch:
+      patchTemplate: |-
+        "metadata":
+          "annotations":
+            "openshift.io/node-selector": "node-role.kubernetes.io/infra="
+          "labels":
+            "openshift.io/cluster-monitoring": "false"
+            "openshift.io/user-monitoring": "false"
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: v1
+        kind: Namespace
+        name: openshift-operators
+  serviceAccountRef:
+    name: patch-sa

--- a/tests/openshift-operators.yml
+++ b/tests/openshift-operators.yml
@@ -1,1 +1,11 @@
-parameters: {}
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.1.0/lib/patch-operator.libsonnet
+        output_path: vendor/lib/patch-operator.libsonnet
+
+  patch_operator:
+    namespace: syn-patch-operator
+    patch_serviceaccount:
+      name: patch-sa


### PR DESCRIPTION
The namespace `openshift-operators` is created and managed by OpenShift itself (via the cluster-version-operator). Until now the component would have taken over ownership of the namespace when used as instance `openshift-operators`. This could lead to undesirable side-effects, such as manually installed operators getting removed when the component instance is deactivated.

This PR updates the component to only create a patch to add our desired labels and annotations to the namespace if it's instantiated for namespace `openshift-operators`.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
