### PR TITLE
Replace patch-operator with espejote

### DIFF
--- a/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
+++ b/tests/golden/openshift-operators/openshift-operators/openshift4-operators/openshift-operators.yaml
@@ -1,26 +1,76 @@
-apiVersion: redhatcop.redhat.io/v1alpha1
-kind: Patch
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    syn.tools/description: |
+      Patches the operator namespace to add the cluster-monitoring label.
   labels:
-    name: namespace-openshift-operators-29c692296e708c9
-  name: namespace-openshift-operators-29c692296e708c9
-  namespace: syn-patch-operator
+    app.kubernetes.io/name: patch-namespace-meta
+  name: patch-namespace-meta
+  namespace: openshift-operators
 spec:
-  patches:
-    namespace-openshift-operators-29c692296e708c9-patch:
-      patchTemplate: |-
-        "metadata":
-          "annotations":
-            "openshift.io/node-selector": ""
-          "labels":
-            "openshift.io/cluster-monitoring": "false"
-            "openshift.io/user-monitoring": "false"
-      patchType: application/strategic-merge-patch+json
-      targetObjectRef:
+  serviceAccountRef:
+    name: patch-namespace-meta
+  template: |-
+    {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "annotations": {
+                "openshift.io/node-selector": ""
+            },
+            "labels": {
+                "openshift.io/cluster-monitoring": "false",
+                "openshift.io/user-monitoring": "false"
+            },
+            "name": "openshift-operators"
+        }
+    }
+  triggers:
+    - name: namespace
+      watchResource:
         apiVersion: v1
         kind: Namespace
         name: openshift-operators
-  serviceAccountRef:
-    name: patch-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: patch-namespace-meta
+    managedresource.espejote.io/name: patch-namespace-meta
+  name: patch-namespace-meta
+  namespace: openshift-operators
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: patch-namespace-meta
+    managedresource.espejote.io/name: patch-namespace-meta
+  name: operator:patch-namespace-meta:openshift-operators
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - openshift-operators
+    resources:
+      - namespaces
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: patch-namespace-meta
+    managedresource.espejote.io/name: patch-namespace-meta
+  name: operator:patch-namespace-meta:openshift-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator:patch-namespace-meta:openshift-operators
+subjects:
+  - kind: ServiceAccount
+    name: patch-namespace-meta
+    namespace: openshift-operators

--- a/tests/openshift-operators.yml
+++ b/tests/openshift-operators.yml
@@ -2,10 +2,5 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.1.0/lib/patch-operator.libsonnet
-        output_path: vendor/lib/patch-operator.libsonnet
-
-  patch_operator:
-    namespace: syn-patch-operator
-    patch_serviceaccount:
-      name: patch-sa
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet


### PR DESCRIPTION
This replaces the namespace label patch with an espejote patch.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
